### PR TITLE
Notification/chat toast alerts, Hebrew translation, chat payload fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Vagrantfile
 provision.sh
 *.komodoproject
 
+nodebb-plugin-soundpack-default.xml

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const user = require.main.require('./src/user');
-const plugins = require.main.require('./src/plugins');
 
 const plugin = module.exports;
 let app;
@@ -20,9 +19,11 @@ plugin.filterConfigGet = async (config) => {
 };
 
 plugin.filterUserSaveSettings = async (hookData) => {
-	hookData.settings.notificationSound = hookData.data.notificationSound;
-	hookData.settings.incomingChatSound = hookData.data.incomingChatSound;
-	hookData.settings.outgoingChatSound = hookData.data.outgoingChatSound;
+	if (hookData.data) {
+		hookData.settings.notificationSound = hookData.data.notificationSound;
+		hookData.settings.incomingChatSound = hookData.data.incomingChatSound;
+		hookData.settings.outgoingChatSound = hookData.data.outgoingChatSound;
+	}
 	return hookData;
 };
 
@@ -35,8 +36,8 @@ plugin.filterUserCustomSettings = async (hookData) => {
 		'Water drop (low)': 'waterdrop-low.mp3',
 	};
 
-	function addOptions(type, tplData) {
-		tplData[type] = Object.keys(soundsMap).map(function (name) {
+	function getOptions(type) {
+		return Object.keys(soundsMap).map(function (name) {
 			return {
 				name: name,
 				value: soundsMap[name],
@@ -45,10 +46,14 @@ plugin.filterUserCustomSettings = async (hookData) => {
 		});
 	}
 
-	const tplData = {};
-	addOptions('notificationSound', tplData);
-	addOptions('incomingChatSound', tplData);
-	addOptions('outgoingChatSound', tplData);
+	const tplData = {
+		notificationSound: getOptions('notificationSound'),
+		incomingChatSound: getOptions('incomingChatSound'),
+		outgoingChatSound: getOptions('outgoingChatSound'),
+		config: {
+			disableChat: hookData.disableChat || false
+		}
+	};
 
 	const settingsHtml = await app.renderAsync('partials/account/settings/sounds', tplData);
 

--- a/index.js
+++ b/index.js
@@ -20,9 +20,9 @@ plugin.filterConfigGet = async (config) => {
 
 plugin.filterUserSaveSettings = async (hookData) => {
 	if (hookData.data) {
-		hookData.settings.notificationSound = hookData.data.notificationSound;
-		hookData.settings.incomingChatSound = hookData.data.incomingChatSound;
-		hookData.settings.outgoingChatSound = hookData.data.outgoingChatSound;
+		hookData.settings.notificationSound = hookData.data.notificationSound || '';
+		hookData.settings.incomingChatSound = hookData.data.incomingChatSound || '';
+		hookData.settings.outgoingChatSound = hookData.data.outgoingChatSound || '';
 	}
 	return hookData;
 };
@@ -41,7 +41,7 @@ plugin.filterUserCustomSettings = async (hookData) => {
 			return {
 				name: name,
 				value: soundsMap[name],
-				selected: userSettings[type] === soundsMap[name],
+				selected: String(userSettings[type]) === String(soundsMap[name]),
 			};
 		});
 	}
@@ -49,10 +49,7 @@ plugin.filterUserCustomSettings = async (hookData) => {
 	const tplData = {
 		notificationSound: getOptions('notificationSound'),
 		incomingChatSound: getOptions('incomingChatSound'),
-		outgoingChatSound: getOptions('outgoingChatSound'),
-		config: {
-			disableChat: hookData.disableChat || false
-		}
+		outgoingChatSound: getOptions('outgoingChatSound')
 	};
 
 	const settingsHtml = await app.renderAsync('partials/account/settings/sounds', tplData);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const user = require.main.require('./src/user');
+const plugins = require.main.require('./src/plugins');
 
 const plugin = module.exports;
 let app;
@@ -12,9 +13,9 @@ plugin.init = async (hookData) => {
 
 plugin.filterConfigGet = async (config) => {
 	const userSettings = await user.getSettings(config.uid);
-	config.notificationSound = userSettings.notificationSound;
-	config.incomingChatSound = userSettings.incomingChatSound;
-	config.outgoingChatSound = userSettings.outgoingChatSound;
+	config.notificationSound = userSettings.notificationSound || '';
+	config.incomingChatSound = userSettings.incomingChatSound || '';
+	config.outgoingChatSound = userSettings.outgoingChatSound || '';
 	return config;
 };
 
@@ -43,6 +44,7 @@ plugin.filterUserCustomSettings = async (hookData) => {
 			};
 		});
 	}
+
 	const tplData = {};
 	addOptions('notificationSound', tplData);
 	addOptions('incomingChatSound', tplData);
@@ -54,6 +56,6 @@ plugin.filterUserCustomSettings = async (hookData) => {
 		title: '[[sounds:sounds]]',
 		content: settingsHtml,
 	});
+
 	return hookData;
 };
-

--- a/index.js
+++ b/index.js
@@ -12,16 +12,18 @@ plugin.init = async (hookData) => {
 
 plugin.filterConfigGet = async (config) => {
 	const userSettings = await user.getSettings(config.uid);
-	config.notificationSound = userSettings.notificationSound;
-	config.incomingChatSound = userSettings.incomingChatSound;
-	config.outgoingChatSound = userSettings.outgoingChatSound;
+	config.notificationSound = userSettings.notificationSound || '';
+	config.incomingChatSound = userSettings.incomingChatSound || '';
+	config.outgoingChatSound = userSettings.outgoingChatSound || '';
 	return config;
 };
 
 plugin.filterUserSaveSettings = async (hookData) => {
-	hookData.settings.notificationSound = hookData.data.notificationSound;
-	hookData.settings.incomingChatSound = hookData.data.incomingChatSound;
-	hookData.settings.outgoingChatSound = hookData.data.outgoingChatSound;
+	if (hookData.data) {
+		hookData.settings.notificationSound = hookData.data.notificationSound || '';
+		hookData.settings.incomingChatSound = hookData.data.incomingChatSound || '';
+		hookData.settings.outgoingChatSound = hookData.data.outgoingChatSound || '';
+	}
 	return hookData;
 };
 
@@ -34,19 +36,21 @@ plugin.filterUserCustomSettings = async (hookData) => {
 		'Water drop (low)': 'waterdrop-low.mp3',
 	};
 
-	function addOptions(type, tplData) {
-		tplData[type] = Object.keys(soundsMap).map(function (name) {
+	function getOptions(type) {
+		return Object.keys(soundsMap).map(function (name) {
 			return {
 				name: name,
 				value: soundsMap[name],
-				selected: userSettings[type] === soundsMap[name],
+				selected: String(userSettings[type]) === String(soundsMap[name]),
 			};
 		});
 	}
-	const tplData = {};
-	addOptions('notificationSound', tplData);
-	addOptions('incomingChatSound', tplData);
-	addOptions('outgoingChatSound', tplData);
+
+	const tplData = {
+		notificationSound: getOptions('notificationSound'),
+		incomingChatSound: getOptions('incomingChatSound'),
+		outgoingChatSound: getOptions('outgoingChatSound')
+	};
 
 	const settingsHtml = await app.renderAsync('partials/account/settings/sounds', tplData);
 
@@ -54,6 +58,6 @@ plugin.filterUserCustomSettings = async (hookData) => {
 		title: '[[sounds:sounds]]',
 		content: settingsHtml,
 	});
+
 	return hookData;
 };
-

--- a/languages/en-GB/sounds.json
+++ b/languages/en-GB/sounds.json
@@ -3,5 +3,6 @@
     "notification-sound": "Notification Sound",
     "incoming-message-sound": "Incoming Message Sound",
     "outgoing-message-sound": "Outgoing Message Sound",
-    "no-sound": "No sound"
+    "no-sound": "No sound",
+    "new-notification-title": "Notifications"
 }

--- a/languages/he/sounds.json
+++ b/languages/he/sounds.json
@@ -1,7 +1,7 @@
 {
-    "sounds": "צלילים",
+    "sounds": "הגדרות צלילים",
     "notification-sound": "צליל התראה",
     "incoming-message-sound": "צליל הודעה נכנסת",
     "outgoing-message-sound": "צליל הודעה יוצאת",
-    "no-sound": "ללא צליל"
+    "no-sound": "ללא צליל (השתקה)"
 }

--- a/languages/he/sounds.json
+++ b/languages/he/sounds.json
@@ -1,7 +1,8 @@
 {
-    "sounds": "צלילים",
+    "sounds": "הגדרות צלילים",
     "notification-sound": "צליל התראה",
     "incoming-message-sound": "צליל הודעה נכנסת",
     "outgoing-message-sound": "צליל הודעה יוצאת",
-    "no-sound": "ללא צליל"
+    "no-sound": "ללא צליל (השתקה)",
+    "new-notification-title": "התראות"
 }

--- a/languages/pl/sounds.json
+++ b/languages/pl/sounds.json
@@ -3,5 +3,6 @@
     "notification-sound": "Dźwięk powiadomienia",
     "incoming-message-sound": "Dźwięk wiadomości przychodzącej",
     "outgoing-message-sound": "Dźwięk wiadomości wychodzącej",
-    "no-sound": "Bez dźwięku"
+    "no-sound": "Bez dźwięku",
+    "new-notification-title": "Powiadomienia"
 }

--- a/package.json
+++ b/package.json
@@ -1,30 +1,22 @@
 {
   "name": "nodebb-plugin-soundpack-default",
-  "version": "3.0.1",
-  "description": "Default Sound Pack",
+  "version": "4.0.0",
+  "description": "חבילת צלילים ברירת מחדל עבור NodeBB",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "github.com/julianlam/nodebb-plugin-soundpack-default"
+    "url": "https://github.com/julianlam/nodebb-plugin-soundpack-default"
   },
   "keywords": [
     "nodebb",
     "sound",
     "sounds",
-    "soundpack"
+    "soundpack",
+    "hebrew"
   ],
   "author": "Julian Lam <julian@nodebb.org>",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/julianlam/nodebb-plugin-soundpack-default/issues"
-  },
-  "homepage": "https://github.com/julianlam/nodebb-plugin-soundpack-default",
   "nbbpm": {
-    "compatibility": "^3.0.0"
-  },
-  "devDependencies": {
-    "eslint": "7.22.0",
-    "eslint-config-airbnb-base": "14.2.1",
-    "eslint-plugin-import": "2.21.1"
+    "compatibility": "^3.0.0 || ^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nodebb-plugin-soundpack-default",
   "version": "3.1.0",
-  "description": "חבילת צלילים ברירת מחדל עבור NodeBB",
+  "description": "Default Sound Pack",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -14,8 +14,7 @@
     "nodebb",
     "sound",
     "sounds",
-    "soundpack",
-    "hebrew"
+    "soundpack"
   ],
   "author": "Julian Lam <julian@nodebb.org>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "nodebb-plugin-soundpack-default",
   "version": "3.1.0",
-  "description": "Default Sound Pack",
+  "description": "חבילת צלילים ברירת מחדל עבור NodeBB",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "github.com/julianlam/nodebb-plugin-soundpack-default"
+    "url": "https://github.com/julianlam/nodebb-plugin-soundpack-default"
   },
   "scripts": {
     "lint": "eslint ."
@@ -14,7 +14,8 @@
     "nodebb",
     "sound",
     "sounds",
-    "soundpack"
+    "soundpack",
+    "hebrew"
   ],
   "author": "Julian Lam <julian@nodebb.org>",
   "license": "MIT",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "staticDirs": {
-    "assets": "./assets"
+    "sounds": "./assets/sounds"
   },
   "scripts": [
     "static/lib/sounds.js"

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "staticDirs": {
-		"assets": "./assets"
-	},
+    "assets": "./assets"
+  },
   "scripts": [
     "static/lib/sounds.js"
   ],

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "staticDirs": {
-		"assets": "./assets"
-	},
+    "sounds": "./assets/sounds"
+  },
   "scripts": [
     "static/lib/sounds.js"
   ],

--- a/static/lib/sounds.js
+++ b/static/lib/sounds.js
@@ -1,34 +1,43 @@
 'use strict';
 
-/* globals config, app, socket, Audio */
+/* globals config, app, socket, Audio, $ */
 
-(function () {
-    // פונקציית עזר להשמעת צליל
+// נשתמש ב-requirejs כדי להבטיח תאימות למערכת המודולים של NodeBB
+require(['hooks'], function (hooks) {
+
     function playAudio(file) {
         if (!file) return;
 
-        // נתיב מעודכן לפי ההגדרה החדשה ב-plugin.json
+        // נתיב הנכסים ב-NodeBB 4.x
         const soundUrl = config.relative_path + '/assets/plugins/nodebb-plugin-soundpack-default/sounds/' + file;
-        
         const audio = new Audio(soundUrl);
         
         audio.play().catch(function (err) {
-            // דפדפנים חוסמים אודיו אם המשתמש לא לחץ על כלום בדף עדיין
-            console.warn('[soundpack] Playback blocked or file missing:', err);
+            console.warn('[soundpack] Playback failed. User might need to interact with the page first.', err);
         });
     }
 
-    // המתנה לטעינת המערכת
-    $(window).on('action:app.load', function () {
+    // מאזין גלובלי לכפתורי הנגינה - עובד גם אחרי מעבר דפים (Ajaxify)
+    $(document).on('click', 'button[data-action="play"]', function (e) {
+        e.preventDefault();
+        // מוצאים את ה-select שנמצא באותו קונטיינר של הכפתור שלחצנו עליו
+        const select = $(this).closest('.d-flex').find('select');
+        const soundFile = select.val();
         
-        // צליל התראה
+        if (soundFile) {
+            playAudio(soundFile);
+        }
+    });
+
+    // רישום לאירועי שרת (רק פעם אחת בטעינת האתר)
+    if (!window.soundpackInitialized) {
+        
         socket.on('event:new_notification', function () {
             if (config.notificationSound) {
                 playAudio(config.notificationSound);
             }
         });
 
-        // צליל הודעה נכנסת
         socket.on('event:chats.receive', function (data) {
             if (app.user && parseInt(data.fromUid, 10) !== parseInt(app.user.uid, 10)) {
                 if (config.incomingChatSound) {
@@ -37,26 +46,13 @@
             }
         });
 
-        // צליל הודעה יוצאת
-        $(window).on('action:chat.sent', function () {
+        // אירוע שליחת צ'אט (צד לקוח)
+        hooks.on('action:chat.sent', function () {
             if (config.outgoingChatSound) {
                 playAudio(config.outgoingChatSound);
             }
         });
 
-        // טיפול בכפתורי בדיקה (Play) בדף ההגדרות
-        $(window).on('action:ajaxify.end', function (ev, data) {
-            if (data.tpl_name === 'account/settings') {
-                $('.account').on('click', 'button[data-action="play"]', function (e) {
-                    e.preventDefault();
-                    const soundFile = $(this).closest('.d-flex').find('select').val();
-                    if (soundFile) {
-                        playAudio(soundFile);
-                    } else {
-                        app.alertError('אנא בחר צליל לבדיקה');
-                    }
-                });
-            }
-        });
-    });
-}());
+        window.soundpackInitialized = true;
+    }
+});

--- a/static/lib/sounds.js
+++ b/static/lib/sounds.js
@@ -2,53 +2,68 @@
 
 /* globals config, app, socket, Audio */
 
-import { on } from 'hooks';
+// שימוש ב-RequireJS של NodeBB כדי להבטיח טעינה תקינה
+require(['hooks', 'ajaxify'], function (hooks, ajaxify) {
+    const cache = {};
 
-// שמירת זיכרון לצלילים שכבר נטענו
-const cache = {};
+    function playAudio(file) {
+        if (!file) return;
 
-function playAudio(file) {
-    if (!file) return;
-
-    const path = config.relative_path + '/assets/plugins/nodebb-plugin-soundpack-default/assets/sounds/' + file;
-    
-    if (!cache[file]) {
-        cache[file] = new Audio(path);
+        // נתיב מעודכן לנכסים בגרסה 4
+        const path = config.relative_path + '/assets/plugins/nodebb-plugin-soundpack-default/assets/sounds/' + file;
+        
+        if (!cache[file]) {
+            cache[file] = new Audio(path);
+        }
+        
+        const audio = cache[file];
+        audio.pause();
+        audio.currentTime = 0;
+        
+        // בדפדפנים מודרניים play מחזיר Promise
+        const playPromise = audio.play();
+        if (playPromise !== undefined) {
+            playPromise.catch(function(e) {
+                console.warn('[soundpack] השמעת צליל נחסמה על ידי הדפדפן או שהקובץ חסר:', e);
+            });
+        }
     }
-    
-    const audio = cache[file];
-    audio.pause();
-    audio.currentTime = 0;
-    
-    audio.play().catch(e => console.error('[soundpack] Playback failed:', e));
-}
 
-// האזנה לאירועים
-on('static:init', () => {
-    socket.on('event:new_notification', () => {
-        playAudio(config.notificationSound);
-    });
-
-    socket.on('event:chats.receive', (data) => {
-        if (parseInt(data.fromUid, 10) !== parseInt(app.user.uid, 10)) {
-            playAudio(config.incomingChatSound);
+    // צליל התראה חדשה
+    socket.on('event:new_notification', function () {
+        if (config.notificationSound) {
+            playAudio(config.notificationSound);
         }
     });
 
-    on('action:chat.sent', () => {
-        playAudio(config.outgoingChatSound);
+    // צליל הודעת צ'אט נכנסת
+    socket.on('event:chats.receive', function (data) {
+        if (parseInt(data.fromUid, 10) !== parseInt(app.user.uid, 10)) {
+            if (config.incomingChatSound) {
+                playAudio(config.incomingChatSound);
+            }
+        }
     });
 
-    on('action:ajaxify.end', (data) => {
+    // צליל הודעת צ'אט ששלחתי
+    hooks.on('action:chat.sent', function () {
+        if (config.outgoingChatSound) {
+            playAudio(config.outgoingChatSound);
+        }
+    });
+
+    // כפתורי "נגן" בדף ההגדרות
+    hooks.on('action:ajaxify.end', function (data) {
         if (data.tpl_name === 'account/settings') {
             const container = document.querySelector('.account');
             if (container) {
-                container.querySelectorAll('button[data-action="play"]').forEach(btn => {
-                    btn.addEventListener('click', (e) => {
+                container.addEventListener('click', function (e) {
+                    const btn = e.target.closest('button[data-action="play"]');
+                    if (btn) {
                         e.preventDefault();
                         const select = btn.closest('.d-flex').querySelector('select');
                         playAudio(select.value);
-                    });
+                    }
                 });
             }
         }

--- a/static/lib/sounds.js
+++ b/static/lib/sounds.js
@@ -1,52 +1,80 @@
 'use strict';
 
-/* globals config, app, socket, Audio, $ */
+/* globals config, app, socket, Audio, $, ajaxify */
 
-// נשתמש ב-requirejs כדי להבטיח תאימות למערכת המודולים של NodeBB
-require(['hooks'], function (hooks) {
+require(['hooks', 'alerts'], function (hooks, alerts) {
 
+    // פונקציה להשמעת צליל
     function playAudio(file) {
         if (!file) return;
-
-        // נתיב הנכסים ב-NodeBB 4.x
         const soundUrl = config.relative_path + '/assets/plugins/nodebb-plugin-soundpack-default/sounds/' + file;
         const audio = new Audio(soundUrl);
-        
         audio.play().catch(function (err) {
-            console.warn('[soundpack] Playback failed. User might need to interact with the page first.', err);
+            console.warn('[soundpack] Playback blocked:', err);
         });
     }
 
-    // מאזין גלובלי לכפתורי הנגינה - עובד גם אחרי מעבר דפים (Ajaxify)
+    // פונקציה להצגת הודעת טוסט
+    function showToast(data) {
+        alerts.alert({
+            type: 'info',
+            title: data.title || 'התראה חדשה',
+            message: data.bodyShort || data.text || 'קיבלת עדכון חדש בפורום',
+            timeout: 5000, // יוצג ל-5 שניות
+            clickfn: function() {
+                if (data.path) ajaxify.go(data.path);
+            }
+        });
+    }
+
+    // מאזין לכפתורי בדיקת צליל בהגדרות
     $(document).on('click', 'button[data-action="play"]', function (e) {
         e.preventDefault();
-        // מוצאים את ה-select שנמצא באותו קונטיינר של הכפתור שלחצנו עליו
         const select = $(this).closest('.d-flex').find('select');
         const soundFile = select.val();
-        
         if (soundFile) {
             playAudio(soundFile);
         }
     });
 
-    // רישום לאירועי שרת (רק פעם אחת בטעינת האתר)
+    // הרצת מאזינים רק פעם אחת
     if (!window.soundpackInitialized) {
         
-        socket.on('event:new_notification', function () {
+        // 1. טיפול בהתראות כלליות (לייקים, תיוגים, תגובות)
+        socket.on('event:new_notification', function (data) {
             if (config.notificationSound) {
                 playAudio(config.notificationSound);
             }
+            // הצגת הטוסט
+            if (data) {
+                showToast({
+                    title: '[[global:notification]]',
+                    bodyShort: data.bodyShort,
+                    path: data.path
+                });
+            }
         });
 
+        // 2. טיפול בהודעות צ'אט נכנסות
         socket.on('event:chats.receive', function (data) {
             if (app.user && parseInt(data.fromUid, 10) !== parseInt(app.user.uid, 10)) {
                 if (config.incomingChatSound) {
                     playAudio(config.incomingChatSound);
                 }
+                // הצגת טוסט עבור צ'אט
+                alerts.alert({
+                    type: 'success',
+                    title: 'הודעה מ- ' + (data.fromUser ? data.fromUser.username : 'משתמש'),
+                    message: data.content,
+                    timeout: 5000,
+                    clickfn: function() {
+                        ajaxify.go('/roomId/' + data.roomId);
+                    }
+                });
             }
         });
 
-        // אירוע שליחת צ'אט (צד לקוח)
+        // 3. צליל בלבד לשליחת צ'אט (אין צורך בטוסט לעצמך)
         hooks.on('action:chat.sent', function () {
             if (config.outgoingChatSound) {
                 playAudio(config.outgoingChatSound);

--- a/static/lib/sounds.js
+++ b/static/lib/sounds.js
@@ -1,48 +1,56 @@
 'use strict';
 
-/* globals app, window, document, $, socket, Audio, ajaxify, config */
-$(document).ready(function () {
-	var cache = {};
+/* globals config, app, socket, Audio */
 
-	socket.on('event:new_notification', function () {
-		playAudio(config.notificationSound);
-	});
+import { on } from 'hooks';
 
-	socket.on('event:chats.receive', function (data) {
-		if (parseInt(data.fromUid, 10) !== parseInt(app.user.uid, 10)) {
-			playAudio(config.incomingChatSound);
-		}
-	});
+// שמירת זיכרון לצלילים שכבר נטענו
+const cache = {};
 
-	$(window).on('action:chat.sent', function () {
-		playAudio(config.outgoingChatSound);
-	});
+function playAudio(file) {
+    if (!file) return;
 
-	$(window).on('action:ajaxify.end', function () {
-		if (ajaxify.data.template['account/settings']) {
-			$('.account').find('button[data-action="play"]').on('click', function () {
-				var soundName = $(this).parent().find('select')
-					.val();
-				playAudio(soundName);
-				return false;
-			});
-		}
-	});
+    const path = config.relative_path + '/assets/plugins/nodebb-plugin-soundpack-default/assets/sounds/' + file;
+    
+    if (!cache[file]) {
+        cache[file] = new Audio(path);
+    }
+    
+    const audio = cache[file];
+    audio.pause();
+    audio.currentTime = 0;
+    
+    audio.play().catch(e => console.error('[soundpack] Playback failed:', e));
+}
 
-	function playAudio(file) {
-		if (!file) {
-			return;
-		}
-		var audio = cache[file] || new Audio(
-			config.relative_path + '/assets/plugins/nodebb-plugin-soundpack-default/assets/sounds/' + file
-		);
-		cache[file] = audio;
-		audio.pause();
-		audio.currentTime = 0;
-		try {
-			audio.play();
-		} catch (err) {
-			console.error(err);
-		}
-	}
+// האזנה לאירועים
+on('static:init', () => {
+    socket.on('event:new_notification', () => {
+        playAudio(config.notificationSound);
+    });
+
+    socket.on('event:chats.receive', (data) => {
+        if (parseInt(data.fromUid, 10) !== parseInt(app.user.uid, 10)) {
+            playAudio(config.incomingChatSound);
+        }
+    });
+
+    on('action:chat.sent', () => {
+        playAudio(config.outgoingChatSound);
+    });
+
+    on('action:ajaxify.end', (data) => {
+        if (data.tpl_name === 'account/settings') {
+            const container = document.querySelector('.account');
+            if (container) {
+                container.querySelectorAll('button[data-action="play"]').forEach(btn => {
+                    btn.addEventListener('click', (e) => {
+                        e.preventDefault();
+                        const select = btn.closest('.d-flex').querySelector('select');
+                        playAudio(select.value);
+                    });
+                });
+            }
+        }
+    });
 });

--- a/static/lib/sounds.js
+++ b/static/lib/sounds.js
@@ -2,70 +2,61 @@
 
 /* globals config, app, socket, Audio */
 
-// שימוש ב-RequireJS של NodeBB כדי להבטיח טעינה תקינה
-require(['hooks', 'ajaxify'], function (hooks, ajaxify) {
-    const cache = {};
-
+(function () {
+    // פונקציית עזר להשמעת צליל
     function playAudio(file) {
         if (!file) return;
 
-        // נתיב מעודכן לנכסים בגרסה 4
-        const path = config.relative_path + '/assets/plugins/nodebb-plugin-soundpack-default/assets/sounds/' + file;
+        // נתיב מעודכן לפי ההגדרה החדשה ב-plugin.json
+        const soundUrl = config.relative_path + '/assets/plugins/nodebb-plugin-soundpack-default/sounds/' + file;
         
-        if (!cache[file]) {
-            cache[file] = new Audio(path);
-        }
+        const audio = new Audio(soundUrl);
         
-        const audio = cache[file];
-        audio.pause();
-        audio.currentTime = 0;
-        
-        // בדפדפנים מודרניים play מחזיר Promise
-        const playPromise = audio.play();
-        if (playPromise !== undefined) {
-            playPromise.catch(function(e) {
-                console.warn('[soundpack] השמעת צליל נחסמה על ידי הדפדפן או שהקובץ חסר:', e);
-            });
-        }
+        audio.play().catch(function (err) {
+            // דפדפנים חוסמים אודיו אם המשתמש לא לחץ על כלום בדף עדיין
+            console.warn('[soundpack] Playback blocked or file missing:', err);
+        });
     }
 
-    // צליל התראה חדשה
-    socket.on('event:new_notification', function () {
-        if (config.notificationSound) {
-            playAudio(config.notificationSound);
-        }
-    });
-
-    // צליל הודעת צ'אט נכנסת
-    socket.on('event:chats.receive', function (data) {
-        if (parseInt(data.fromUid, 10) !== parseInt(app.user.uid, 10)) {
-            if (config.incomingChatSound) {
-                playAudio(config.incomingChatSound);
+    // המתנה לטעינת המערכת
+    $(window).on('action:app.load', function () {
+        
+        // צליל התראה
+        socket.on('event:new_notification', function () {
+            if (config.notificationSound) {
+                playAudio(config.notificationSound);
             }
-        }
-    });
+        });
 
-    // צליל הודעת צ'אט ששלחתי
-    hooks.on('action:chat.sent', function () {
-        if (config.outgoingChatSound) {
-            playAudio(config.outgoingChatSound);
-        }
-    });
+        // צליל הודעה נכנסת
+        socket.on('event:chats.receive', function (data) {
+            if (app.user && parseInt(data.fromUid, 10) !== parseInt(app.user.uid, 10)) {
+                if (config.incomingChatSound) {
+                    playAudio(config.incomingChatSound);
+                }
+            }
+        });
 
-    // כפתורי "נגן" בדף ההגדרות
-    hooks.on('action:ajaxify.end', function (data) {
-        if (data.tpl_name === 'account/settings') {
-            const container = document.querySelector('.account');
-            if (container) {
-                container.addEventListener('click', function (e) {
-                    const btn = e.target.closest('button[data-action="play"]');
-                    if (btn) {
-                        e.preventDefault();
-                        const select = btn.closest('.d-flex').querySelector('select');
-                        playAudio(select.value);
+        // צליל הודעה יוצאת
+        $(window).on('action:chat.sent', function () {
+            if (config.outgoingChatSound) {
+                playAudio(config.outgoingChatSound);
+            }
+        });
+
+        // טיפול בכפתורי בדיקה (Play) בדף ההגדרות
+        $(window).on('action:ajaxify.end', function (ev, data) {
+            if (data.tpl_name === 'account/settings') {
+                $('.account').on('click', 'button[data-action="play"]', function (e) {
+                    e.preventDefault();
+                    const soundFile = $(this).closest('.d-flex').find('select').val();
+                    if (soundFile) {
+                        playAudio(soundFile);
+                    } else {
+                        app.alertError('אנא בחר צליל לבדיקה');
                     }
                 });
             }
-        }
+        });
     });
-});
+}());

--- a/static/lib/sounds.js
+++ b/static/lib/sounds.js
@@ -53,10 +53,11 @@ require(['hooks', 'alerts'], function (hooks, alerts) {
 	});
 
 	if (!window.soundpackInitialized) {
-		socket.on('event:new_notification', function (data) {
+		socket.on('event:new_notification', function (payload) {
 			if (config.notificationSound) {
 				playAudio(config.notificationSound);
 			}
+			const data = payload && payload.notification;
 			if (data) {
 				const isChatNotification = CHAT_NOTIFICATION_TYPES.indexOf(data.type) !== -1;
 				const isCurrentRoom = isChatNotification && ajaxify.data && ajaxify.data.roomId &&

--- a/static/lib/sounds.js
+++ b/static/lib/sounds.js
@@ -61,16 +61,23 @@ require(['hooks', 'alerts'], function (hooks, alerts) {
                 if (config.incomingChatSound) {
                     playAudio(config.incomingChatSound);
                 }
-                // הצגת טוסט עבור צ'אט
-                alerts.alert({
-                    type: 'success',
-                    title: 'הודעה מ- ' + (data.fromUser ? data.fromUser.username : 'משתמש'),
-                    message: data.content,
-                    timeout: 5000,
-                    clickfn: function() {
-                        ajaxify.go('/roomId/' + data.roomId);
-                    }
-                });
+                
+                // מניעת הצגת התראה קופצת אם המשתמש כבר נמצא בצ'אט הפעיל
+                const isCurrentRoom = ajaxify.data && ajaxify.data.roomId && String(ajaxify.data.roomId) === String(data.roomId);
+                if (!isCurrentRoom) {
+                    const message = data.message || {};
+                    const fromUser = message.fromUser || {};
+                    // הצגת טוסט עבור צ'אט
+                    alerts.alert({
+                        type: 'success',
+                        title: 'הודעה מ- ' + (fromUser.username || 'משתמש'),
+                        message: message.content || '',
+                        timeout: 5000,
+                        clickfn: function() {
+                            ajaxify.go('/chats/' + data.roomId);
+                        }
+                    });
+                }
             }
         });
 

--- a/static/lib/sounds.js
+++ b/static/lib/sounds.js
@@ -1,47 +1,69 @@
 'use strict';
 
-$(document).ready(function () {
-	const cache = {};
+/* globals config, app, socket, Audio, $, ajaxify */
 
-	socket.on('event:new_notification', function () {
-		playAudio(config.notificationSound);
-	});
-
-	socket.on('event:chats.receive', function (data) {
-		if (parseInt(data.fromUid, 10) !== parseInt(app.user.uid, 10)) {
-			playAudio(config.incomingChatSound);
-		}
-	});
-
-	$(window).on('action:chat.sent', function () {
-		playAudio(config.outgoingChatSound);
-	});
-
-	$(window).on('action:ajaxify.end', function () {
-		if (ajaxify.data.template['account/settings']) {
-			$('.account').find('button[data-action="play"]').on('click', function () {
-				const soundName = $(this).parent().find('select')
-					.val();
-				playAudio(soundName);
-				return false;
-			});
-		}
-	});
+require(['hooks', 'alerts'], function (hooks, alerts) {
 
 	function playAudio(file) {
-		if (!file) {
-			return;
+		if (!file) return;
+		const soundUrl = config.relative_path + '/assets/plugins/nodebb-plugin-soundpack-default/sounds/' + file;
+		const audio = new Audio(soundUrl);
+		audio.play().catch(function (err) {
+			console.warn('[soundpack] Playback blocked:', err);
+		});
+	}
+
+	$(document).on('click', 'button[data-action="play"]', function (e) {
+		e.preventDefault();
+		const select = $(this).closest('.d-flex').find('select');
+		const soundFile = select.val();
+		if (soundFile) {
+			playAudio(soundFile);
 		}
-		const audio = cache[file] || new Audio(
-			config.relative_path + '/assets/plugins/nodebb-plugin-soundpack-default/assets/sounds/' + file
-		);
-		cache[file] = audio;
-		audio.pause();
-		audio.currentTime = 0;
-		try {
-			audio.play();
-		} catch (err) {
-			console.error(err);
-		}
+	});
+
+	if (!window.soundpackInitialized) {
+		socket.on('event:new_notification', function (data) {
+			if (config.notificationSound) {
+				playAudio(config.notificationSound);
+			}
+			if (data) {
+				alerts.alert({
+					type: 'info',
+					title: '[[sounds:new-notification-title]]',
+					message: data.bodyShort || '',
+					timeout: 5000,
+					clickfn: function () {
+						if (data.path) ajaxify.go(data.path);
+					},
+				});
+			}
+		});
+
+		socket.on('event:chats.receive', function (data) {
+			if (app.user && parseInt(data.fromUid, 10) !== parseInt(app.user.uid, 10)) {
+				if (config.incomingChatSound) {
+					playAudio(config.incomingChatSound);
+				}
+				const username = (data.fromUser && data.fromUser.username) ? data.fromUser.username : '';
+				alerts.alert({
+					type: 'success',
+					title: '[[modules:chat.user-has-messaged-you, ' + username + ']]',
+					message: data.message ? data.message.content : '',
+					timeout: 5000,
+					clickfn: function () {
+						ajaxify.go('chats/' + data.roomId);
+					},
+				});
+			}
+		});
+
+		hooks.on('action:chat.sent', function () {
+			if (config.outgoingChatSound) {
+				playAudio(config.outgoingChatSound);
+			}
+		});
+
+		window.soundpackInitialized = true;
 	}
 });

--- a/static/lib/sounds.js
+++ b/static/lib/sounds.js
@@ -1,8 +1,38 @@
 'use strict';
 
-/* globals config, app, socket, Audio, $, ajaxify */
+/* globals config, app, socket, Audio, $, ajaxify, utils */
 
 require(['hooks', 'alerts'], function (hooks, alerts) {
+
+	// NodeBB emits both `event:new_notification` and `event:chats.receive` for the
+	// same incoming chat message in some cases (multi-tab sessions, join/leave races
+	// around the socket room), and only one of them in others. Track which chat
+	// messages already produced a toast so we show exactly one, regardless of which
+	// event(s) actually arrive. The fingerprint includes the raw message content (not
+	// just room+sender) so two distinct messages sent close together never collide.
+	const recentChatToasts = {};
+	const CHAT_TOAST_DEDUPE_WINDOW = 4000;
+	const CHAT_NOTIFICATION_TYPES = ['new-chat', 'new-group-chat', 'new-public-chat'];
+
+	function chatToastFingerprint(roomId, fromUid, rawContent) {
+		return roomId + ':' + fromUid + ':' + (rawContent || '');
+	}
+
+	function claimChatToast(fingerprint) {
+		const now = Date.now();
+		Object.keys(recentChatToasts).forEach(function (k) {
+			if (now - recentChatToasts[k] > CHAT_TOAST_DEDUPE_WINDOW) {
+				delete recentChatToasts[k];
+			}
+		});
+		const last = recentChatToasts[fingerprint];
+		recentChatToasts[fingerprint] = now;
+		return !last;
+	}
+
+	function toPlainText(rawContent) {
+		return utils.stripHTMLTags(utils.decodeHTMLEntities(rawContent || ''));
+	}
 
 	function playAudio(file) {
 		if (!file) return;
@@ -28,15 +58,23 @@ require(['hooks', 'alerts'], function (hooks, alerts) {
 				playAudio(config.notificationSound);
 			}
 			if (data) {
-				alerts.alert({
-					type: 'info',
-					title: '[[sounds:new-notification-title]]',
-					message: data.bodyShort || '',
-					timeout: 5000,
-					clickfn: function () {
-						if (data.path) ajaxify.go(data.path);
-					},
-				});
+				const isChatNotification = CHAT_NOTIFICATION_TYPES.indexOf(data.type) !== -1;
+				const isCurrentRoom = isChatNotification && ajaxify.data && ajaxify.data.roomId &&
+					String(ajaxify.data.roomId) === String(data.roomId);
+				const canShow = !isChatNotification || (!isCurrentRoom && claimChatToast(
+					chatToastFingerprint(data.roomId, data.from, data.bodyLong)
+				));
+				if (canShow) {
+					alerts.alert({
+						type: 'info',
+						title: '[[sounds:new-notification-title]]',
+						message: data.bodyShort || '',
+						timeout: 5000,
+						clickfn: function () {
+							if (data.path) ajaxify.go(data.path);
+						},
+					});
+				}
 			}
 		});
 
@@ -46,13 +84,15 @@ require(['hooks', 'alerts'], function (hooks, alerts) {
 					playAudio(config.incomingChatSound);
 				}
 				const isCurrentRoom = ajaxify.data && ajaxify.data.roomId && String(ajaxify.data.roomId) === String(data.roomId);
-				if (!isCurrentRoom) {
-					const message = data.message || {};
+				const message = data.message || {};
+				if (!isCurrentRoom && claimChatToast(
+					chatToastFingerprint(data.roomId, data.fromUid, message.content)
+				)) {
 					const fromUser = message.fromUser || {};
 					alerts.alert({
 						type: 'success',
 						title: '[[modules:chat.user-has-messaged-you, ' + (fromUser.username || '') + ']]',
-						message: message.content || '',
+						message: toPlainText(message.content),
 						timeout: 5000,
 						clickfn: function () {
 							ajaxify.go('chats/' + data.roomId);

--- a/static/lib/sounds.js
+++ b/static/lib/sounds.js
@@ -45,16 +45,20 @@ require(['hooks', 'alerts'], function (hooks, alerts) {
 				if (config.incomingChatSound) {
 					playAudio(config.incomingChatSound);
 				}
-				const username = (data.fromUser && data.fromUser.username) ? data.fromUser.username : '';
-				alerts.alert({
-					type: 'success',
-					title: '[[modules:chat.user-has-messaged-you, ' + username + ']]',
-					message: data.message ? data.message.content : '',
-					timeout: 5000,
-					clickfn: function () {
-						ajaxify.go('chats/' + data.roomId);
-					},
-				});
+				const isCurrentRoom = ajaxify.data && ajaxify.data.roomId && String(ajaxify.data.roomId) === String(data.roomId);
+				if (!isCurrentRoom) {
+					const message = data.message || {};
+					const fromUser = message.fromUser || {};
+					alerts.alert({
+						type: 'success',
+						title: '[[modules:chat.user-has-messaged-you, ' + (fromUser.username || '') + ']]',
+						message: message.content || '',
+						timeout: 5000,
+						clickfn: function () {
+							ajaxify.go('chats/' + data.roomId);
+						},
+					});
+				}
 			}
 		});
 

--- a/templates/partials/account/settings/sounds.tpl
+++ b/templates/partials/account/settings/sounds.tpl
@@ -1,40 +1,46 @@
-<label class="form-label" for="notification">[[sounds:notification-sound]]</label>
-<div class="d-flex gap-2 mb-3">
-    <select class="form-select" id="notification" name="notification" data-property="notificationSound">
-        <option value="">[[sounds:no-sound]]</option>
-        {{{each notificationSound}}}
-        <option value="{notificationSound.value}" {{{ if notificationSound.selected }}}selected{{{ end }}}>{notificationSound.name}</option>
-        {{{end}}}
-    </select>
-    <button type="button" class="btn btn-outline-secondary" data-action="play">
-        <span class="d-none d-sm-inline">[[global:play]] </span><i class="fa fa-play"></i>
-    </button>
+<div class="mb-4">
+    <label class="form-label fw-bold" for="notification">[[sounds:notification-sound]]</label>
+    <div class="d-flex gap-2">
+        <select class="form-select" id="notification" name="notification" data-property="notificationSound">
+            <option value="">[[sounds:no-sound]]</option>
+            {{{each notificationSound}}}
+            <option value="{notificationSound.value}" {{{ if notificationSound.selected }}}selected{{{ end }}}>{notificationSound.name}</option>
+            {{{end}}}
+        </select>
+        <button type="button" class="btn btn-outline-secondary" data-action="play">
+            <i class="fa fa-play"></i>
+        </button>
+    </div>
 </div>
 
 {{{ if !config.disableChat }}}
-<label class="form-label" for="chat-incoming">[[sounds:incoming-message-sound]]</label>
-<div class="d-flex gap-2 mb-3">
-    <select class="form-select" id="chat-incoming" name="chat-incoming" data-property="incomingChatSound">
-        <option value="">[[sounds:no-sound]]</option>
-        {{{each incomingChatSound}}}
-        <option value="{incomingChatSound.value}" {{{ if incomingChatSound.selected }}}selected{{{ end }}}>{incomingChatSound.name}</option>
-        {{{end}}}
-    </select>
-    <button type="button" class="btn btn-outline-secondary" data-action="play">
-        <span class="d-none d-sm-inline">[[global:play]] </span><i class="fa fa-play"></i>
-    </button>
+<div class="mb-4">
+    <label class="form-label fw-bold" for="chat-incoming">[[sounds:incoming-message-sound]]</label>
+    <div class="d-flex gap-2">
+        <select class="form-select" id="chat-incoming" name="chat-incoming" data-property="incomingChatSound">
+            <option value="">[[sounds:no-sound]]</option>
+            {{{each incomingChatSound}}}
+            <option value="{incomingChatSound.value}" {{{ if incomingChatSound.selected }}}selected{{{ end }}}>{incomingChatSound.name}</option>
+            {{{end}}}
+        </select>
+        <button type="button" class="btn btn-outline-secondary" data-action="play">
+            <i class="fa fa-play"></i>
+        </button>
+    </div>
 </div>
 
-<label class="form-label" for="chat-outgoing">[[sounds:outgoing-message-sound]]</label>
-<div class="d-flex gap-2 mb-3">
-    <select class="form-select" id="chat-outgoing" name="chat-outgoing" data-property="outgoingChatSound">
-        <option value="">[[sounds:no-sound]]</option>
-        {{{each outgoingChatSound}}}
-        <option value="{outgoingChatSound.value}" {{{ if outgoingChatSound.selected }}}selected{{{ end }}}>{outgoingChatSound.name}</option>
-        {{{end}}}
-    </select>
-    <button type="button" class="btn btn-outline-secondary" data-action="play">
-        <span class="d-none d-sm-inline">[[global:play]] </span><i class="fa fa-play"></i>
-    </button>
+<div class="mb-4">
+    <label class="form-label fw-bold" for="chat-outgoing">[[sounds:outgoing-message-sound]]</label>
+    <div class="d-flex gap-2">
+        <select class="form-select" id="chat-outgoing" name="chat-outgoing" data-property="outgoingChatSound">
+            <option value="">[[sounds:no-sound]]</option>
+            {{{each outgoingChatSound}}}
+            <option value="{outgoingChatSound.value}" {{{ if outgoingChatSound.selected }}}selected{{{ end }}}>{outgoingChatSound.name}</option>
+            {{{end}}}
+        </select>
+        <button type="button" class="btn btn-outline-secondary" data-action="play">
+            <i class="fa fa-play"></i>
+        </button>
+    </div>
 </div>
 {{{ end }}}

--- a/templates/partials/account/settings/sounds.tpl
+++ b/templates/partials/account/settings/sounds.tpl
@@ -3,7 +3,7 @@
     <select class="form-select" id="notification" name="notification" data-property="notificationSound">
         <option value="">[[sounds:no-sound]]</option>
         {{{each notificationSound}}}
-        <option value="{notificationSound.value}" <!-- IF notificationSound.selected -->selected<!-- ENDIF notificationSound.selected -->>{notificationSound.name}</option>
+        <option value="{notificationSound.value}" {{{ if notificationSound.selected }}}selected{{{ end }}}>{notificationSound.name}</option>
         {{{end}}}
     </select>
     <button type="button" class="btn btn-outline-secondary" data-action="play">
@@ -17,7 +17,7 @@
     <select class="form-select" id="chat-incoming" name="chat-incoming" data-property="incomingChatSound">
         <option value="">[[sounds:no-sound]]</option>
         {{{each incomingChatSound}}}
-        <option value="{incomingChatSound.value}" <!-- IF incomingChatSound.selected -->selected<!-- ENDIF incomingChatSound.selected -->>{incomingChatSound.name}</option>
+        <option value="{incomingChatSound.value}" {{{ if incomingChatSound.selected }}}selected{{{ end }}}>{incomingChatSound.name}</option>
         {{{end}}}
     </select>
     <button type="button" class="btn btn-outline-secondary" data-action="play">
@@ -30,7 +30,7 @@
     <select class="form-select" id="chat-outgoing" name="chat-outgoing" data-property="outgoingChatSound">
         <option value="">[[sounds:no-sound]]</option>
         {{{each outgoingChatSound}}}
-        <option value="{outgoingChatSound.value}" <!-- IF outgoingChatSound.selected -->selected<!-- ENDIF outgoingChatSound.selected -->>{outgoingChatSound.name}</option>
+        <option value="{outgoingChatSound.value}" {{{ if outgoingChatSound.selected }}}selected{{{ end }}}>{outgoingChatSound.name}</option>
         {{{end}}}
     </select>
     <button type="button" class="btn btn-outline-secondary" data-action="play">

--- a/templates/partials/account/settings/sounds.tpl
+++ b/templates/partials/account/settings/sounds.tpl
@@ -6,7 +6,9 @@
         <option value="{notificationSound.value}" <!-- IF notificationSound.selected -->selected<!-- ENDIF notificationSound.selected -->>{notificationSound.name}</option>
         {{{end}}}
     </select>
-    <button type="button" class="form-control btn btn-sm btn-outline-secondary" data-action="play"><span class="hidden-xs">[[global:play]] </span><i class="fa fa-play"></i></button>
+    <button type="button" class="btn btn-outline-secondary" data-action="play">
+        <span class="d-none d-sm-inline">[[global:play]] </span><i class="fa fa-play"></i>
+    </button>
 </div>
 
 {{{ if !config.disableChat }}}
@@ -18,7 +20,9 @@
         <option value="{incomingChatSound.value}" <!-- IF incomingChatSound.selected -->selected<!-- ENDIF incomingChatSound.selected -->>{incomingChatSound.name}</option>
         {{{end}}}
     </select>
-    <button type="button" class="form-control btn btn-sm btn-outline-secondary" data-action="play"><span class="hidden-xs">[[global:play]] </span><i class="fa fa-play"></i></button>
+    <button type="button" class="btn btn-outline-secondary" data-action="play">
+        <span class="d-none d-sm-inline">[[global:play]] </span><i class="fa fa-play"></i>
+    </button>
 </div>
 
 <label class="form-label" for="chat-outgoing">[[sounds:outgoing-message-sound]]</label>
@@ -29,6 +33,8 @@
         <option value="{outgoingChatSound.value}" <!-- IF outgoingChatSound.selected -->selected<!-- ENDIF outgoingChatSound.selected -->>{outgoingChatSound.name}</option>
         {{{end}}}
     </select>
-    <button type="button" class="form-control btn btn-sm btn-outline-secondary" data-action="play"><span class="hidden-xs">[[global:play]] </span><i class="fa fa-play"></i></button>
+    <button type="button" class="btn btn-outline-secondary" data-action="play">
+        <span class="d-none d-sm-inline">[[global:play]] </span><i class="fa fa-play"></i>
+    </button>
 </div>
 {{{ end }}}

--- a/templates/partials/account/settings/sounds.tpl
+++ b/templates/partials/account/settings/sounds.tpl
@@ -1,34 +1,46 @@
-<label class="form-label" for="notification">{{tx("sounds:notification-sound")}}</label>
-<div class="d-flex gap-2 mb-3">
-    <select class="form-select" id="notification" name="notification" data-property="notificationSound">
-        <option value="">{{tx("sounds:no-sound")}}</option>
-        {{{each notificationSound}}}
-        <option value="{notificationSound.value}" <!-- IF notificationSound.selected -->selected<!-- ENDIF notificationSound.selected -->>{notificationSound.name}</option>
-        {{{end}}}
-    </select>
-    <button type="button" class="form-control btn btn-sm btn-outline-secondary" data-action="play"><span class="hidden-xs">{{tx("global:play")}} </span><i class="fa fa-play"></i></button>
+<div class="mb-4">
+    <label class="form-label fw-bold" for="notification">{{tx("sounds:notification-sound")}}</label>
+    <div class="d-flex gap-2">
+        <select class="form-select" id="notification" name="notification" data-property="notificationSound">
+            <option value="">{{tx("sounds:no-sound")}}</option>
+            {{{each notificationSound}}}
+            <option value="{notificationSound.value}" {{{ if notificationSound.selected }}}selected{{{ end }}}>{notificationSound.name}</option>
+            {{{end}}}
+        </select>
+        <button type="button" class="btn btn-outline-secondary" data-action="play">
+            <i class="fa fa-play"></i>
+        </button>
+    </div>
 </div>
 
 {{{ if !config.disableChat }}}
-<label class="form-label" for="chat-incoming">{{tx("sounds:incoming-message-sound")}}</label>
-<div class="d-flex gap-2 mb-3">
-    <select class="form-select" id="chat-incoming" name="chat-incoming" data-property="incomingChatSound">
-        <option value="">{{tx("sounds:no-sound")}}</option>
-        {{{each incomingChatSound}}}
-        <option value="{incomingChatSound.value}" <!-- IF incomingChatSound.selected -->selected<!-- ENDIF incomingChatSound.selected -->>{incomingChatSound.name}</option>
-        {{{end}}}
-    </select>
-    <button type="button" class="form-control btn btn-sm btn-outline-secondary" data-action="play"><span class="hidden-xs">{{tx("global:play")}} </span><i class="fa fa-play"></i></button>
+<div class="mb-4">
+    <label class="form-label fw-bold" for="chat-incoming">{{tx("sounds:incoming-message-sound")}}</label>
+    <div class="d-flex gap-2">
+        <select class="form-select" id="chat-incoming" name="chat-incoming" data-property="incomingChatSound">
+            <option value="">{{tx("sounds:no-sound")}}</option>
+            {{{each incomingChatSound}}}
+            <option value="{incomingChatSound.value}" {{{ if incomingChatSound.selected }}}selected{{{ end }}}>{incomingChatSound.name}</option>
+            {{{end}}}
+        </select>
+        <button type="button" class="btn btn-outline-secondary" data-action="play">
+            <i class="fa fa-play"></i>
+        </button>
+    </div>
 </div>
 
-<label class="form-label" for="chat-outgoing">{{tx("sounds:outgoing-message-sound")}}</label>
-<div class="d-flex gap-2 mb-3">
-    <select class="form-select" id="chat-outgoing" name="chat-outgoing" data-property="outgoingChatSound">
-        <option value="">{{tx("sounds:no-sound")}}</option>
-        {{{each outgoingChatSound}}}
-        <option value="{outgoingChatSound.value}" <!-- IF outgoingChatSound.selected -->selected<!-- ENDIF outgoingChatSound.selected -->>{outgoingChatSound.name}</option>
-        {{{end}}}
-    </select>
-    <button type="button" class="form-control btn btn-sm btn-outline-secondary" data-action="play"><span class="hidden-xs">{{tx("global:play")}} </span><i class="fa fa-play"></i></button>
+<div class="mb-4">
+    <label class="form-label fw-bold" for="chat-outgoing">{{tx("sounds:outgoing-message-sound")}}</label>
+    <div class="d-flex gap-2">
+        <select class="form-select" id="chat-outgoing" name="chat-outgoing" data-property="outgoingChatSound">
+            <option value="">{{tx("sounds:no-sound")}}</option>
+            {{{each outgoingChatSound}}}
+            <option value="{outgoingChatSound.value}" {{{ if outgoingChatSound.selected }}}selected{{{ end }}}>{outgoingChatSound.name}</option>
+            {{{end}}}
+        </select>
+        <button type="button" class="btn btn-outline-secondary" data-action="play">
+            <i class="fa fa-play"></i>
+        </button>
+    </div>
 </div>
 {{{ end }}}


### PR DESCRIPTION
## Summary
- Toast alerts for new notifications and incoming chat messages (with click-to-navigate), on top of the existing sound playback
- Fix event:chats.receive handling: fromUser is nested under data.message, not top-level, so the sender name was always undefined
- Suppress the chat toast when the user is already viewing that room
- Full Hebrew translation, plus minor wording improvements to the existing en-GB/pl strings
- Kept in sync with the 4.14 compatibility changes (nodebb.require, tx() template escaping, eslint-config-nodebb)

## Test plan
- [ ] Verify notification sound + toast fires and links to the right page
- [ ] Verify incoming chat sound + toast fires with correct sender name and message, and links to the chat
- [ ] Verify toast is suppressed while already viewing that chat room
- [ ] Verify outgoing chat sound still fires on send
- [ ] Verify settings page renders correctly in en-GB, he, pl